### PR TITLE
feat: add checks for built-in exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A checker for Flake8 that helps format nice error messages. The checks are:
 - **EM102**: Check for raw usage of an f-string literal in Exception raising.
 - **EM103**: Check for raw usage of `.format` on a string literal in Exception
   raising.
+- **EM104**: Check for missing parentheses for built-in exceptions.
+- **EM105**: Check for missing message for built-in exceptions.
 
 The issue is that Python includes the line with the raise in the default
 traceback (and most other formatters, like Rich and IPython to too). That means
@@ -78,7 +80,8 @@ script entry-point (`pipx run flake8-errmsg <files>`) or module entry-point
 Q: Why Python 3.10+ only? <br/> A: This is a static checker and for developers.
 Developers and static checks should be on 3.10 already. And I was lazy and match
 statements are fantastic for this sort of thing. And the AST module changed in
-3.8 anyway.
+3.8 anyway. Use [Ruff][] (which contains the checks from this plugin) if you
+need to run on older versions.
 
 Q: What other sorts of checks are acceptable? <br/> A: Things that help with
 nice errors. For example, maybe requiring `raise SystemExit(n)` over `sys.exit`,
@@ -91,4 +94,5 @@ nice errors. For example, maybe requiring `raise SystemExit(n)` over `sys.exit`,
 [pypi-link]:                https://pypi.org/project/flake8-errmsg/
 [pypi-platforms]:           https://img.shields.io/pypi/pyversions/flake8-errmsg
 [pypi-version]:             https://img.shields.io/pypi/v/flake8-errmsg
+[ruff]:                      https://github.com/astral-sh/ruff
 <!-- prettier-ignore-end -->

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -61,3 +61,32 @@ def test_err2():
         results[0].msg
         == "EM103 Exception must not use a .format() string directly, assign to variable first"
     )
+
+
+ERR3 = """\
+raise RuntimeError
+"""
+
+
+def test_err3():
+    node = ast.parse(ERR3)
+    results = list(m.ErrMsgASTPlugin(node).run())
+    assert len(results) == 1
+    assert results[0].line_number == 1
+    assert (
+        results[0].msg
+        == "EM104 Built-in Exceptions must not be thrown without being called"
+    )
+
+
+ERR4 = """\
+raise RuntimeError()
+"""
+
+
+def test_err4():
+    node = ast.parse(ERR4)
+    results = list(m.ErrMsgASTPlugin(node).run())
+    assert len(results) == 1
+    assert results[0].line_number == 1
+    assert results[0].msg == "EM105 Built-in Exceptions must have a useful message"


### PR DESCRIPTION
Closes #13. This can only be done for built-in exceptions, since there's no way to tell if a variable is a class or an object.
