### PR TITLE
fix: improve readability

### DIFF
--- a/src/flake8_errmsg/__init__.py
+++ b/src/flake8_errmsg/__init__.py
@@ -68,17 +68,22 @@ class Visitor(ast.NodeVisitor):
 
 
 def EM101(node: ast.stmt) -> Flake8ASTErrorInfo:
-    msg = "EM101 Exception must not use a string literal, assign to variable first"
+    msg = "EM101 Exceptions must not use a string literal; assign to a variable first"
     return Flake8ASTErrorInfo(node.lineno, node.col_offset, msg, Visitor)
 
 
 def EM102(node: ast.stmt) -> Flake8ASTErrorInfo:
-    msg = "EM102 Exception must not use an f-string literal, assign to variable first"
+    msg = (
+        "EM102 Exceptions must not use an f-string literal; assign to a variable first"
+    )
     return Flake8ASTErrorInfo(node.lineno, node.col_offset, msg, Visitor)
 
 
 def EM103(node: ast.stmt) -> Flake8ASTErrorInfo:
-    msg = "EM103 Exception must not use a .format() string directly, assign to variable first"
+    msg = (
+        "EM103 Exceptions must not use a .format() string directly; "
+        "assign to a variable first"
+    )
     return Flake8ASTErrorInfo(node.lineno, node.col_offset, msg, Visitor)
 
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -25,11 +25,11 @@ def test_err1():
 
     assert (
         results[0].msg
-        == "EM101 Exception must not use a string literal, assign to variable first"
+        == "EM101 Exceptions must not use a string literal; assign to a variable first"
     )
     assert (
         results[1].msg
-        == "EM102 Exception must not use an f-string literal, assign to variable first"
+        == "EM102 Exceptions must not use an f-string literal; assign to a variable first"
     )
 
 
@@ -43,7 +43,7 @@ def test_string_length():
 
     assert (
         results[0].msg
-        == "EM102 Exception must not use an f-string literal, assign to variable first"
+        == "EM102 Exceptions must not use an f-string literal; assign to a variable first"
     )
 
 
@@ -59,7 +59,7 @@ def test_err2():
     assert results[0].line_number == 1
     assert (
         results[0].msg
-        == "EM103 Exception must not use a .format() string directly, assign to variable first"
+        == "EM103 Exceptions must not use a .format() string directly; assign to a variable first"
     )
 
 


### PR DESCRIPTION
This may be a nit, but here is why I believe these changes improve readability:

- Clarity: Adding “a” (“assign to a variable first”) fixes the grammar and reads more naturally. Splitting with “;” makes the guidance easier to scan as two parts: the rule and the action.
- Consistency: EM101–EM103 now match the plural form already used in EM104 and EM105 (“Exceptions must not…”), which is more consistent across rules.
- Style: The semicolon is clearer than the prior [comma splice](https://en.wikipedia.org/wiki/Comma_splice).

As for verbosity, the messages are slightly longer, but still concise for CLI output. Specificity remains unchanged and the directive remains clear at a glance.