### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.0.0
       - name: Run PyLint
         run: uvx nox -s pylint -- --output-format=github
 
@@ -40,7 +40,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.0.0
 
       - name: Test package
         run: |


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830

Committed via https://github.com/asottile/all-repos