### PR TITLE
fix: don't flag EM106 walruses inside nested lambdas

### DIFF
--- a/src/flake8_errmsg/__init__.py
+++ b/src/flake8_errmsg/__init__.py
@@ -73,8 +73,17 @@ class Visitor(ast.NodeVisitor):
 
 
 def _contains_namedexpr(node: ast.AST) -> bool:
-    """Return True if the node or any of its descendants contains a walrus."""
-    return any(isinstance(child, ast.NamedExpr) for child in ast.walk(node))
+    """Return True if the node contains a walrus that binds in the raise's scope.
+
+    Lambdas introduce a new scope, so a walrus inside one does not name the
+    exception message and is not flagged (e.g. a ``key=lambda x: (y := x)``).
+    """
+    if isinstance(node, ast.NamedExpr):
+        return True
+    return any(
+        not isinstance(child, ast.Lambda) and _contains_namedexpr(child)
+        for child in ast.iter_child_nodes(node)
+    )
 
 
 def _error(node: ast.stmt, msg: str) -> Flake8ASTErrorInfo:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -156,3 +156,15 @@ def test_err9_namedexpr_outside_raise_ok():
     results = list(m.ErrMsgASTPlugin(node).run())
     # No EM106 should be reported; raise does not contain a walrus expression directly
     assert results == []
+
+
+ERR10 = """\
+raise ValueError(sorted(xs, key=lambda v: (k := v))[0])
+"""
+
+
+def test_err10_namedexpr_in_lambda_ok():
+    node = ast.parse(ERR10)
+    results = list(m.ErrMsgASTPlugin(node).run())
+    # The walrus binds in the lambda's own scope, not the raise's, so no EM106.
+    assert results == []


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes item 1 of #86.

`_contains_namedexpr` used `ast.walk`, which descends into every nested scope. A walrus inside a lambda passed to a `raise` argument was therefore flagged EM106 even though it binds in the lambda's own scope and never names the exception message:

```python
raise ValueError(sorted(xs, key=lambda v: (k := v))[0])   # previously EM106, a false positive
```

This replaces the walk with a recursive check that stops at `ast.Lambda` boundaries. Direct walruses in the raise arguments/keywords are still flagged exactly as before (existing EM106 tests unchanged).

Added `test_err10_namedexpr_in_lambda_ok`. All tests pass.