### PR TITLE
fix: flag EM103 on f-string .format() receivers

### DIFF
--- a/src/flake8_errmsg/__init__.py
+++ b/src/flake8_errmsg/__init__.py
@@ -50,7 +50,11 @@ class Visitor(ast.NodeVisitor):
                 self.errors.append(EM102(node))
             case ast.Call(
                 args=[
-                    ast.Call(func=ast.Attribute(attr="format", value=ast.Constant())),
+                    ast.Call(
+                        func=ast.Attribute(
+                            attr="format", value=ast.Constant() | ast.JoinedStr()
+                        )
+                    ),
                     *_,
                 ]
             ):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -63,6 +63,22 @@ def test_err2():
     )
 
 
+ERR2B = """\
+raise RuntimeError(f"this {x} is".format())
+"""
+
+
+def test_err2b_fstring_format():
+    node = ast.parse(ERR2B)
+    results = list(m.ErrMsgASTPlugin(node).run())
+    assert len(results) == 1
+    assert results[0].line_number == 1
+    assert (
+        results[0].msg
+        == "EM103 Exceptions must not use a .format() string directly; assign to a variable first"
+    )
+
+
 ERR3 = """\
 raise RuntimeError
 """


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes item 2 of #86.

EM103 only matched `.format()` when the receiver was a plain string `Constant`, so an f-string receiver slipped through **every** check:

```python
raise RuntimeError(f"{x}".format())   # previously unflagged
```

The pattern now also matches an `ast.JoinedStr` receiver, reporting it as EM103 (the construct is a direct `.format()` call). Added `test_err2b_fstring_format`. All tests pass.