### PR TITLE
chore: bump to 0.7.0

### DIFF
--- a/src/flake8_errmsg/__init__.py
+++ b/src/flake8_errmsg/__init__.py
@@ -18,7 +18,7 @@ from typing import Any, ClassVar, NamedTuple
 
 __all__ = ("ErrMsgASTPlugin", "__version__", "main", "run_on_file")
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 BUILTIN_EXCEPTIONS = frozenset(
     name


### PR DESCRIPTION
Bumping to 0.7.0 instead of 0.6.1 because the format f-string fix could trigger a new discovery that was missed before.

---

### Fixed
- EM103 now flags `.format()` receivers on f-strings (#88) — previously missed.
- EM106 no longer false-positives on walruses inside nested lambdas (#87).
- Corrected plugin version reported by the plugin, dropped dead code, and tidied error constructors (#85).

### Tests
- Added coverage for CLI paths and the string-length boundary; clarified the `cls` comment (#89).

### Chores / CI
- Support Python 3.15 (#92)
- Support pylint 4 (#72).
- `pytest` config switched to `log_level` over `log_cli_level` (#75).
- Added an `AGENTS` file (#84).
- Bumped `setup-uv` (6→7, then to the maintained tag scheme, then 8.1.0→8.2.0), `download-artifact` (5→6), and other grouped action updates (#90, #82, #80, #74, #71, #70).
- Several routine pre-commit hook updates (#83, #79, #77, #73, #69).

